### PR TITLE
feat: Add more sad path tests for activity

### DIFF
--- a/test/activityRepo-test.js
+++ b/test/activityRepo-test.js
@@ -123,12 +123,36 @@ describe('UserActivity', () => {
       expect(activityRepo.dailyMilesWalked(1, '2023/03/25')).to.be.undefined;
     });
 
+    it('should not be able to calculate miles walked if date provided is not a string', () => {
+      expect(activityRepo.dailyMilesWalked(1, 2023/03/24)).to.be.undefined;
+    });
+
+    it('should not be able to calculate miles walked if date provided is in incorrect order', () => {
+      expect(activityRepo.dailyMilesWalked(1, "03/24/2023")).to.be.undefined;
+    });
+
+    it('should not be able to calculate miles walked if both id and date are not provided', () => {
+      expect(activityRepo.dailyMilesWalked(1)).to.be.undefined;
+    });
+
     it('should be able to tell the user minutes active by specified date', () => {
       expect(activityRepo.dailyMinActive(1, '2023/03/24')).to.equal(261);
     });
 
     it('should not be able to tell the user minutes active when provided a wrong date', () => {
       expect(activityRepo.dailyMinActive(1, '2023/03/25')).to.be.undefined;
+    });
+
+    it('should not be able to calculate miles walked if date provided is not a string', () => {
+      expect(activityRepo.dailyMinActive(1, 2023/03/24)).to.be.undefined;
+    });
+
+    it('should not be able to calculate miles walked if date provided is in incorrect order', () => {
+      expect(activityRepo.dailyMinActive(1, "03/24/2023")).to.be.undefined;
+    });
+
+    it('should not be able to calculate miles walked if both id and date are not provided', () => {
+      expect(activityRepo.dailyMinActive(1)).to.be.undefined;
     });
 
     it('should be able to tell if the user has did not reach step goal', () => {
@@ -142,4 +166,16 @@ describe('UserActivity', () => {
     it('should not be able to tell the user step goals when provided a wrong date', () => {
       expect(activityRepo.stepGoalReached(1, '2023/03/25')).to.equal(false);
     });  
+
+    it('should not be able to calculate miles walked if date provided is not a string', () => {
+      expect(activityRepo.stepGoalReached(1, 2023/03/24)).to.be.undefined;
+    });
+
+    it('should not be able to calculate miles walked if date provided is in incorrect order', () => {
+      expect(activityRepo.stepGoalReached(1, "03/24/2023")).to.be.undefined;
+    });
+
+    it('should not be able to calculate miles walked if both id and date are not provided', () => {
+      expect(activityRepo.stepGoalReached(1)).to.be.undefined;
+    });
 })


### PR DESCRIPTION
### Please check for the following requirements:
- [x] I have reviewed this PR's changes at least once
- [x] I have added tests for the functionality of any new or updated features, if applicable
- [x] My code follows the style guidelines of this project

### Types of changes:
- [ ] Bugfix
- [ ] Build
- [ ] Documentation
- [x] Feature
- [ ] Refactor

### Describe your changes:
[//]: <> (Which files were changed? What changes were made?)
activityRepo-test - I added additional tests for sad paths for activity section, including sad paths for when user doesn't input both arguments (id and date) and inputs date in the wrong format (i.e. not as a string and not in year/month/date format).

### What is the current behavior?
[//]: <> (Are there any issues / errors? Anything needing additional review?)
- Current Behavior: n/a

